### PR TITLE
handle reloaded dergons a little bit better

### DIFF
--- a/src/no/runsafe/dergons/Dergon.java
+++ b/src/no/runsafe/dergons/Dergon.java
@@ -105,7 +105,7 @@ public class Dergon extends EntityInsentient implements IComplex, IMonster
 					{
 						rawChum.startRiding(this);
 						ridingPlayer = unluckyChum;
-						handler.handleDergonMount(ridingPlayer.getName());
+						handler.handleDergonMount(ridingPlayer);
 					}
 				}
 			}

--- a/src/no/runsafe/dergons/Dergon.java
+++ b/src/no/runsafe/dergons/Dergon.java
@@ -436,11 +436,13 @@ public class Dergon extends EntityInsentient implements IComplex, IMonster
 		else
 			bossBar.setTitle("RogueDergon (" + pct + "%)");
 
+		bossBar.setProgress(pct);
+
 		// Handle which players can see the boss bar
 
 		if (targetWorld == null) return;
 
-		List<IPlayer> playersInRange = targetWorld.getLocation(locX, locY, locZ).getPlayersInRange(400);
+		List<IPlayer> playersInRange = targetWorld.getLocation(locX, locY, locZ).getPlayersInRange(150);
 		List<IPlayer> bossBarPlayers = bossBar.getPlayers();
 
 		// Remove players who are too far away
@@ -543,11 +545,9 @@ public class Dergon extends EntityInsentient implements IComplex, IMonster
 	@Override
 	protected void bO()
 	{
+		bossBar.removeAllPlayers();
 		if (dead)
-		{
-			bossBar.removeAllPlayers();
 			return;
-		}
 
 		// Increment death ticks.
 		this.deathTicks++;
@@ -580,7 +580,6 @@ public class Dergon extends EntityInsentient implements IComplex, IMonster
 		// When animation is finished, slay the dergon.
 		if(this.deathTicks == 200)
 		{
-			bossBar.removeAllPlayers();
 			die();
 			if (handler != null)
 				handler.handleDergonDeath(this);

--- a/src/no/runsafe/dergons/Dergon.java
+++ b/src/no/runsafe/dergons/Dergon.java
@@ -51,12 +51,16 @@ public class Dergon extends EntityInsentient implements IComplex, IMonster
 		this.fireProof = true;
 		this.persistent = true;
 
-		this.handler = handler;
+		if (handler != null)
+			this.handler = handler;
+		else
+			this.handler = new DergonHandler();
+
 		this.targetLocation = targetLocation;
 		this.targetWorld = targetLocation.getWorld();
 		this.dergonID = dergonID;
 
-		if (handler != null)
+		if (dergonID > -1)
 			this.bossBar = new RunsafeBossBar("Dergon", BarColour.PURPLE, BarStyle.SOLID);
 		else
 			this.bossBar = new RunsafeBossBar("RogueDergon", BarColour.RED, BarStyle.SOLID);
@@ -90,7 +94,7 @@ public class Dergon extends EntityInsentient implements IComplex, IMonster
 			flyOffLocation = null;
 
 		// Check if we have any close players, if we do, fly away.
-		if (dergonLocation != null && !dergonLocation.getPlayersInRange(10).isEmpty() && handler != null)
+		if (dergonLocation != null && !dergonLocation.getPlayersInRange(10).isEmpty())
 		{
 			if (ridingPlayer == null && random.nextFloat() < 0.5F)
 			{
@@ -431,7 +435,7 @@ public class Dergon extends EntityInsentient implements IComplex, IMonster
 	{
 		// Update the health bar to show the percentage of the dergon
 		long pct = round((getHealth() / getMaxHealth()) * 100);
-		if (handler != null)
+		if (dergonID > -1)
 			bossBar.setTitle("Dergon (" + pct + "%)");
 		else
 			bossBar.setTitle("RogueDergon (" + pct + "%)");
@@ -471,12 +475,7 @@ public class Dergon extends EntityInsentient implements IComplex, IMonster
 	{
 		for (Entity entity : list)
 			if (entity instanceof EntityLiving)
-			{
-				if (handler != null)
 					entity.damageEntity(DamageSource.mobAttack(this), handler.getDergonAttackingDamage());
-				else
-					entity.damageEntity(DamageSource.mobAttack(this), 20.0F);
-			}
 	}
 
 	/**
@@ -527,9 +526,6 @@ public class Dergon extends EntityInsentient implements IComplex, IMonster
 	@Override
 	protected boolean damageEntity0(DamageSource source, float damageValue)
 	{
-		if (handler == null)
-			return super.damageEntity0(source, damageValue);
-
 		if (ridingPlayer == null || !isRidingPlayer(source.getEntity().getName()))
 			return super.damageEntity0(source, handler.handleDergonDamage(this, source, damageValue));
 
@@ -581,8 +577,7 @@ public class Dergon extends EntityInsentient implements IComplex, IMonster
 		if(this.deathTicks == 200)
 		{
 			die();
-			if (handler != null)
-				handler.handleDergonDeath(this);
+			handler.handleDergonDeath(this);
 		}
 	}
 

--- a/src/no/runsafe/dergons/DergonHandler.java
+++ b/src/no/runsafe/dergons/DergonHandler.java
@@ -5,7 +5,6 @@ import no.runsafe.dergons.event.*;
 import no.runsafe.framework.api.*;
 import no.runsafe.framework.api.event.plugin.IConfigurationChanged;
 import no.runsafe.framework.api.event.plugin.IPluginEnabled;
-import no.runsafe.framework.api.log.IConsole;
 import no.runsafe.framework.api.player.IPlayer;
 import no.runsafe.framework.internal.wrapper.ObjectWrapper;
 import no.runsafe.framework.tools.nms.EntityRegister;
@@ -14,27 +13,26 @@ import java.util.*;
 
 public class DergonHandler implements IConfigurationChanged, IPluginEnabled
 {
-	public DergonHandler(IScheduler scheduler, IConsole console)
+	public DergonHandler(IScheduler scheduler)
 	{
 		this.scheduler = scheduler;
-		this.console = console;
 	}
 
 	public DergonHandler()
 	{
-		this(null,null);
+		this(null);
 	}
 
 	public int spawnDergon(ILocation location)
 	{
 		IWorld world = location.getWorld();
-		if (world == null || scheduler == null || console == null)
+		if (world == null || scheduler == null)
 			return -1;
 
 		location.offset(0, spawnY, 0); // Set the location to be high in the sky.
 		activeDergons.put( // Construct the dergon.
 			currentDergonID,
-			new DergonHolder(console, scheduler, location, eventMinTime, eventMaxTime, stepCount, minSpawnY, this, currentDergonID, baseHealth)
+			new DergonHolder(scheduler, location, eventMinTime, eventMaxTime, stepCount, minSpawnY, this, currentDergonID, baseHealth)
 		);
 		return currentDergonID++;
 	}
@@ -182,7 +180,6 @@ public class DergonHandler implements IConfigurationChanged, IPluginEnabled
 	private static float baseHealth;
 	private static final HashMap<Integer, HashMap<IPlayer, Float>> damageCounter = new HashMap<>(0);
 	private static final HashMap<Integer, DergonHolder> activeDergons = new HashMap<>(0);
-	private final IConsole console;
 	private static final Random random = new Random();
 	private static int currentDergonID = 1;
 }

--- a/src/no/runsafe/dergons/DergonHandler.java
+++ b/src/no/runsafe/dergons/DergonHandler.java
@@ -20,10 +20,15 @@ public class DergonHandler implements IConfigurationChanged, IPluginEnabled
 		this.console = console;
 	}
 
+	public DergonHandler()
+	{
+		this(null,null);
+	}
+
 	public int spawnDergon(ILocation location)
 	{
 		IWorld world = location.getWorld();
-		if (world == null)
+		if (world == null || scheduler == null || console == null)
 			return -1;
 
 		location.offset(0, spawnY, 0); // Set the location to be high in the sky.
@@ -82,6 +87,9 @@ public class DergonHandler implements IConfigurationChanged, IPluginEnabled
 				new DergonSnowballEvent(attackingPlayer).Fire();
 
 			int dergonID = dergon.getDergonID();
+
+			if (dergonID < 0)
+				return damage;
 
 			if (!damageCounter.containsKey(dergonID))
 				damageCounter.put(dergonID, new HashMap<>(0));
@@ -165,16 +173,16 @@ public class DergonHandler implements IConfigurationChanged, IPluginEnabled
 	}
 
 	private final IScheduler scheduler;
-	private int spawnY;
-	private int eventMinTime;
-	private int eventMaxTime;
-	private int stepCount;
-	private int minSpawnY;
-	private float baseDamage;
-	private float baseHealth;
-	private final HashMap<Integer, HashMap<IPlayer, Float>> damageCounter = new HashMap<>(0);
-	private final HashMap<Integer, DergonHolder> activeDergons = new HashMap<>(0);
+	private static int spawnY;
+	private static int eventMinTime;
+	private static int eventMaxTime;
+	private static int stepCount;
+	private static int minSpawnY;
+	private static float baseDamage;
+	private static float baseHealth;
+	private static final HashMap<Integer, HashMap<IPlayer, Float>> damageCounter = new HashMap<>(0);
+	private static final HashMap<Integer, DergonHolder> activeDergons = new HashMap<>(0);
 	private final IConsole console;
-	private final Random random = new Random();
-	private int currentDergonID = 1;
+	private static final Random random = new Random();
+	private static int currentDergonID = 1;
 }

--- a/src/no/runsafe/dergons/DergonHandler.java
+++ b/src/no/runsafe/dergons/DergonHandler.java
@@ -7,9 +7,12 @@ import no.runsafe.framework.api.event.plugin.IConfigurationChanged;
 import no.runsafe.framework.api.event.plugin.IPluginEnabled;
 import no.runsafe.framework.api.player.IPlayer;
 import no.runsafe.framework.internal.wrapper.ObjectWrapper;
+import no.runsafe.framework.minecraft.bossBar.*;
 import no.runsafe.framework.tools.nms.EntityRegister;
 
 import java.util.*;
+
+import static java.lang.Math.round;
 
 public class DergonHandler implements IConfigurationChanged, IPluginEnabled
 {
@@ -136,6 +139,7 @@ public class DergonHandler implements IConfigurationChanged, IPluginEnabled
 			damageCounter.remove(dergonID); // Remove the tracking for this dergon.
 		}
 		activeDergons.remove(dergonID);
+		removeBossBar(dergonID);
 
 		if (slayer != null)
 			new DergonSlayEvent(slayer).Fire();
@@ -170,6 +174,34 @@ public class DergonHandler implements IConfigurationChanged, IPluginEnabled
 		return info;
 	}
 
+	public void createBossBar(int dergonID)
+	{
+		if (dergonID < 0) return;
+
+		dergonBossBars.put(dergonID, new RunsafeBossBar("Dergon", BarColour.PURPLE, BarStyle.SOLID));
+	}
+
+	public void updateBossBar(int dergonID, float currentHealth, float maxHealth, List<IPlayer> newBarPlayers)
+	{
+		if (dergonID < 0) return;
+
+		// Update the health bar to show the percentage of the dergon
+		long pct = round((currentHealth / maxHealth));
+		dergonBossBars.get(dergonID).setTitle("Dergon (" + (pct * 100) + "%)");
+		dergonBossBars.get(dergonID).setProgress(pct);
+
+		// Handle which players can see the boss bar
+		dergonBossBars.get(dergonID).setActivePlayers(newBarPlayers);
+	}
+
+	public void removeBossBar(int dergonID)
+	{
+		if (dergonID < 0) return;
+
+		dergonBossBars.get(dergonID).removeAllPlayers();
+		dergonBossBars.remove(dergonID);
+	}
+
 	private final IScheduler scheduler;
 	private static int spawnY;
 	private static int eventMinTime;
@@ -180,6 +212,7 @@ public class DergonHandler implements IConfigurationChanged, IPluginEnabled
 	private static float baseHealth;
 	private static final HashMap<Integer, HashMap<IPlayer, Float>> damageCounter = new HashMap<>(0);
 	private static final HashMap<Integer, DergonHolder> activeDergons = new HashMap<>(0);
+	private static final HashMap<Integer, IBossBar> dergonBossBars = new HashMap<>(0);
 	private static final Random random = new Random();
 	private static int currentDergonID = 1;
 }

--- a/src/no/runsafe/dergons/DergonHandler.java
+++ b/src/no/runsafe/dergons/DergonHandler.java
@@ -7,17 +7,17 @@ import no.runsafe.framework.api.event.plugin.IConfigurationChanged;
 import no.runsafe.framework.api.event.plugin.IPluginEnabled;
 import no.runsafe.framework.api.log.IConsole;
 import no.runsafe.framework.api.player.IPlayer;
+import no.runsafe.framework.internal.wrapper.ObjectWrapper;
 import no.runsafe.framework.tools.nms.EntityRegister;
 
 import java.util.*;
 
 public class DergonHandler implements IConfigurationChanged, IPluginEnabled
 {
-	public DergonHandler(IScheduler scheduler, IConsole console, IServer server)
+	public DergonHandler(IScheduler scheduler, IConsole console)
 	{
 		this.scheduler = scheduler;
 		this.console = console;
-		this.server = server;
 	}
 
 	public int spawnDergon(ILocation location)
@@ -74,22 +74,22 @@ public class DergonHandler implements IConfigurationChanged, IPluginEnabled
 			damage = 6.0F;
 
 		Entity attackingEntity = source.getEntity();
-		if (attackingEntity != null && attackingEntity instanceof EntityPlayer)
+		if (attackingEntity instanceof EntityPlayer)
 		{
-			String playerName = attackingEntity.getName();
+			IPlayer attackingPlayer = ObjectWrapper.convert((EntityPlayer) attackingEntity);
 
 			if (source instanceof EntityDamageSourceIndirect && source.i() != null && source.i() instanceof EntitySnowball)
-				new DergonSnowballEvent(server.getPlayerExact(playerName)).Fire();
+				new DergonSnowballEvent(attackingPlayer).Fire();
 
 			int dergonID = dergon.getDergonID();
 
 			if (!damageCounter.containsKey(dergonID))
-				damageCounter.put(dergonID, new HashMap<String, Float>(0));
+				damageCounter.put(dergonID, new HashMap<>(0));
 
-			if (!damageCounter.get(dergonID).containsKey(playerName))
-				damageCounter.get(dergonID).put(playerName, damage);
+			if (!damageCounter.get(dergonID).containsKey(attackingPlayer))
+				damageCounter.get(dergonID).put(attackingPlayer, damage);
 			else
-				damageCounter.get(dergonID).put(playerName, damageCounter.get(dergonID).get(playerName) + damage);
+				damageCounter.get(dergonID).put(attackingPlayer, damageCounter.get(dergonID).get(attackingPlayer) + damage);
 		}
 
 		return damage;
@@ -115,9 +115,9 @@ public class DergonHandler implements IConfigurationChanged, IPluginEnabled
 
 		if (damageCounter.containsKey(dergonID))
 		{
-			for (Map.Entry<String, Float> node : damageCounter.get(dergonID).entrySet())
+			for (Map.Entry<IPlayer, Float> node : damageCounter.get(dergonID).entrySet())
 			{
-				IPlayer player = server.getPlayerExact(node.getKey());
+				IPlayer player = node.getKey();
 				new DergonAssistEvent(player).Fire();
 
 				float damage = node.getValue();
@@ -135,9 +135,9 @@ public class DergonHandler implements IConfigurationChanged, IPluginEnabled
 			new DergonSlayEvent(slayer).Fire();
 	}
 
-	public void handleDergonMount(String playerName)
+	public void handleDergonMount(IPlayer player)
 	{
-		new DergonMountEvent(server.getPlayerExact(playerName)).Fire();
+		new DergonMountEvent(player).Fire();
 	}
 
 	public Set<Integer> getAllDergonIDs()
@@ -172,10 +172,9 @@ public class DergonHandler implements IConfigurationChanged, IPluginEnabled
 	private int minSpawnY;
 	private float baseDamage;
 	private float baseHealth;
-	private final HashMap<Integer, HashMap<String, Float>> damageCounter = new HashMap<Integer, HashMap<String, Float>>(0);
+	private final HashMap<Integer, HashMap<IPlayer, Float>> damageCounter = new HashMap<>(0);
 	private final HashMap<Integer, DergonHolder> activeDergons = new HashMap<>(0);
 	private final IConsole console;
-	private final IServer server;
 	private final Random random = new Random();
 	private int currentDergonID = 1;
 }

--- a/src/no/runsafe/dergons/DergonHolder.java
+++ b/src/no/runsafe/dergons/DergonHolder.java
@@ -14,9 +14,8 @@ import java.util.Random;
 
 public class DergonHolder
 {
-	public DergonHolder(IConsole console, IScheduler scheduler, ILocation targetLocation, int min, int max, int steps, int minY, DergonHandler handler, int dergonID, float baseHealth)
+	public DergonHolder(IScheduler scheduler, ILocation targetLocation, int min, int max, int steps, int minY, DergonHandler handler, int dergonID, float baseHealth)
 	{
-		this.console = console;
 		this.scheduler = scheduler;
 		this.targetLocation = targetLocation;
 		this.handler = handler;
@@ -63,8 +62,7 @@ public class DergonHolder
 				heldDergon.setCustomName("Dergon");
 				heldDergon.getAttributeInstance(GenericAttributes.maxHealth).setValue(health);
 				heldDergon.setHealth(health);
-				if (!rawWorld.addEntity(heldDergon))
-					console.logWarning("Dergon with ID:%d could not be added to the world.", dergonID);
+				rawWorld.addEntity(heldDergon);
 			}
 		}
 	}
@@ -116,7 +114,6 @@ public class DergonHolder
 	private Dergon heldDergon;
 	private int currentStep = 0;
 	private final IScheduler scheduler;
-	private final IConsole console;
 	private final ILocation targetLocation;
 	private final IWorld world;
 	private final int minStep;


### PR DESCRIPTION
move boss bars into DergonHandler so if a dergon gets reloaded the boss bar isn't lost for ever and stuck at the top of a player's screen.

give respawned dergons its very own dergon handler.

I plan on adding a way for them to get their original ID back at a later time, but this should work a bit better than how it currently works